### PR TITLE
Fix compiler errors for unknown type name 'fd_set'

### DIFF
--- a/srf-ip-conn-srv/api.h
+++ b/srf-ip-conn-srv/api.h
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include <time.h>
 #include <stdlib.h>
+#include <sys/select.h>
 
 typedef struct api_client {
 	int sock;

--- a/srf-ip-conn-srv/main.c
+++ b/srf-ip-conn-srv/main.c
@@ -35,6 +35,7 @@ DEALINGS IN THE SOFTWARE.
 #include <signal.h>
 #include <syslog.h>
 #include <sys/stat.h>
+#include <sys/select.h>
 #include <time.h>
 
 #define MAIN_FORK_RESULT_OK				0


### PR DESCRIPTION
While compiling on Alpine Linux I was getting these errors:

```
Scanning dependencies of target srf-ip-conn-srv
[  7%] Building C object CMakeFiles/srf-ip-conn-srv.dir/app/srf-ip-conn/srf-ip-conn/common/srf-ip-conn-packet.c.o
[ 14%] Building C object CMakeFiles/srf-ip-conn-srv.dir/app/srf-ip-conn/srf-ip-conn/common/sha2.c.o
[ 21%] Building C object CMakeFiles/srf-ip-conn-srv.dir/app/srf-ip-conn-srv/main.c.o
[ 28%] Building C object CMakeFiles/srf-ip-conn-srv.dir/app/jsmn/jsmn.c.o
In file included from /app/srf-ip-conn-srv/main.c:30:0:
/app/srf-ip-conn-srv/api.h:42:31: error: unknown type name 'fd_set'
 int api_add_clients_to_fd_set(fd_set *fds);
                               ^
/app/srf-ip-conn-srv/api.h:43:25: error: unknown type name 'fd_set'
 void api_process_fd_set(fd_set *fds);
                         ^
/app/srf-ip-conn-srv/main.c: In function 'main_select':
/app/srf-ip-conn-srv/main.c:154:2: error: unknown type name 'fd_set'
  fd_set rfds;
  ^
/app/srf-ip-conn-srv/main.c:155:9: error: variable 'timeout' has initializer but incomplete type
  struct timeval timeout = { .tv_sec = 1, .tv_usec = 0 }; // Blocking only for 1 second.
         ^
/app/srf-ip-conn-srv/main.c:155:9: error: unknown field 'tv_sec' specified in initializer
/app/srf-ip-conn-srv/main.c:155:39: warning: excess elements in struct initializer
  struct timeval timeout = { .tv_sec = 1, .tv_usec = 0 }; // Blocking only for 1 second.
                                       ^
/app/srf-ip-conn-srv/main.c:155:39: note: (near initialization for 'timeout')
/app/srf-ip-conn-srv/main.c:155:9: error: unknown field 'tv_usec' specified in initializer
  struct timeval timeout = { .tv_sec = 1, .tv_usec = 0 }; // Blocking only for 1 second.
         ^
/app/srf-ip-conn-srv/main.c:155:53: warning: excess elements in struct initializer
  struct timeval timeout = { .tv_sec = 1, .tv_usec = 0 }; // Blocking only for 1 second.
                                                     ^
/app/srf-ip-conn-srv/main.c:155:53: note: (near initialization for 'timeout')
/app/srf-ip-conn-srv/main.c:155:17: error: storage size of 'timeout' isn't known
  struct timeval timeout = { .tv_sec = 1, .tv_usec = 0 }; // Blocking only for 1 second.
                 ^
/app/srf-ip-conn-srv/main.c:160:2: warning: implicit declaration of function 'FD_ZERO' [-Wimplicit-function-declaration]
  FD_ZERO(&rfds);
  ^
/app/srf-ip-conn-srv/main.c:161:2: warning: implicit declaration of function 'FD_SET' [-Wimplicit-function-declaration]
  FD_SET(main_server_sock_fd, &rfds);
  ^
In file included from /app/srf-ip-conn-srv/main.c:26:0:
/app/srf-ip-conn-srv/main.c:166:22: warning: implicit declaration of function 'api_add_clients_to_fd_set' [-Wimplicit-function-declaration]
   maxfd = max(maxfd, api_add_clients_to_fd_set(&rfds));
                      ^
/app/srf-ip-conn-srv/types.h:36:27: note: in definition of macro 'max'
 #define max(a,b) (((a) > (b)) ? (a) : (b))
                           ^
/app/srf-ip-conn-srv/main.c:169:10: warning: implicit declaration of function 'select' [-Wimplicit-function-declaration]
  switch (select(maxfd+1, &rfds, NULL, NULL, &timeout)) {
          ^
/app/srf-ip-conn-srv/main.c:175:8: warning: implicit declaration of function 'FD_ISSET' [-Wimplicit-function-declaration]
    if (FD_ISSET(main_server_sock_fd, &rfds)) {
        ^
/app/srf-ip-conn-srv/main.c:195:4: warning: implicit declaration of function 'api_process_fd_set' [-Wimplicit-function-declaration]
    api_process_fd_set(&rfds);
    ^
/app/srf-ip-conn-srv/main.c:155:17: warning: unused variable 'timeout' [-Wunused-variable]
  struct timeval timeout = { .tv_sec = 1, .tv_usec = 0 }; // Blocking only for 1 second.
                 ^
make[2]: *** [CMakeFiles/srf-ip-conn-srv.dir/app/srf-ip-conn-srv/main.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/srf-ip-conn-srv.dir/build.make:134: recipe for target 'CMakeFiles/srf-ip-conn-srv.dir/app/srf-ip-conn-srv/main.c.o' failed
[ 35%] Building C object CMakeFiles/srf-ip-conn-srv.dir/app/srf-ip-conn-srv/config.c.o
make[1]: *** [CMakeFiles/srf-ip-conn-srv.dir/all] Error 2
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/srf-ip-conn-srv.dir/all' failed
make: *** [all] Error 2
Makefile:83: recipe for target 'all' failed
```
