### PR TITLE
Use HTTPS for external dashboard resources

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,13 +5,13 @@
 		<link rel="icon" type="image/x-icon" href="favicon.ico"/>
 		<link rel="shortcut icon" type="image/x-icon" href="favicon.ico"/>
 		<link rel="stylesheet" href="style.css">
-		<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css">
-		<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap-theme.min.css">
-		<link rel="stylesheet" href="//cdn.jsdelivr.net/alertifyjs/1.8.0/css/alertify.min.css"/>
-		<link rel="stylesheet" href="//cdn.jsdelivr.net/alertifyjs/1.8.0/css/themes/bootstrap.min.css"/>
-		<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-		<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"></script>
-		<script src="//cdn.jsdelivr.net/alertifyjs/1.8.0/alertify.min.js"></script>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap-theme.min.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/alertifyjs/1.8.0/css/alertify.min.css"/>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/alertifyjs/1.8.0/css/themes/bootstrap.min.css"/>
+		<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/alertifyjs/1.8.0/alertify.min.js"></script>
 		<title>SharkRF IP Connector Protocol Server Dashboard</title>
 	</head>
 


### PR DESCRIPTION
I've got my dashboard running with SSL. In order to allow the loading of the resources they must be on HTTPS also. Using network-path reference urls so CDN hosted assets will be accessed on HTTP when the dashboard is loaded on HTTP isn't recommended either.
