### PR TITLE
Add ability to configure interval client list status syslog

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -6,7 +6,7 @@
   "max-api-clients": 100,
   "client-login-timeout-sec": 10,
   "client-timeout-sec": 30,
-  "client-status-syslog-interval": 30,
+  "client-status-syslog-interval-sec": 30,
   "server-password": "",
   "auth-fail-ip-ignore-sec": 5,
   "pidfile": "srf-ip-conn-srv.pid",

--- a/config-example.json
+++ b/config-example.json
@@ -6,6 +6,7 @@
   "max-api-clients": 100,
   "client-login-timeout-sec": 10,
   "client-timeout-sec": 30,
+  "client-status-syslog-interval": 30,
   "server-password": "",
   "auth-fail-ip-ignore-sec": 5,
   "pidfile": "srf-ip-conn-srv.pid",

--- a/srf-ip-conn-srv/client.c
+++ b/srf-ip-conn-srv/client.c
@@ -361,7 +361,7 @@ void client_process(void) {
 		ip = ip->next;
 	}
 
-	if (time(NULL)-last_client_list_log_at > config_client_status_syslog_interval) {
+	if (time(NULL)-last_client_list_log_at > config_client_status_syslog_interval_sec) {
 		last_client_list_log_at = time(NULL);
 
 		if (clients == NULL)

--- a/srf-ip-conn-srv/client.c
+++ b/srf-ip-conn-srv/client.c
@@ -361,7 +361,7 @@ void client_process(void) {
 		ip = ip->next;
 	}
 
-	if (time(NULL)-last_client_list_log_at > 30) {
+	if (time(NULL)-last_client_list_log_at > config_client_status_syslog_interval) {
 		last_client_list_log_at = time(NULL);
 
 		if (clients == NULL)

--- a/srf-ip-conn-srv/config.c
+++ b/srf-ip-conn-srv/config.c
@@ -47,6 +47,7 @@ char config_server_contact_str[255] = {0,};
 uint16_t config_max_lastheard_entry_count = 30;
 uint16_t config_max_api_clients = 100;
 uint16_t config_client_call_timeout_sec = 3;
+uint16_t config_client_status_syslog_interval = 30;
 flag_t config_allow_simultaneous_calls = 0;
 char config_banlist_file_str[255] = {0,};
 
@@ -55,7 +56,7 @@ flag_t config_read(char *filename) {
 	long fsize;
 	char *buf;
 	jsmn_parser json_parser;
-	jsmntok_t tok[34];
+	jsmntok_t tok[35];
 	int json_entry_count;
 	int i;
 	char port_str[6] = {0,};
@@ -74,6 +75,7 @@ flag_t config_read(char *filename) {
 	char max_lastheard_entry_count_str[6] = {0,};
 	char max_api_clients_str[6] = {0,};
 	char client_call_timeout_sec_str[6] = {0,};
+	char client_status_syslog_interval_str[6] = {0,};
 	char allow_simultaneous_calls_str[2] = {0,};
 	char banlist_file_str[255] = {0,};
 
@@ -158,6 +160,9 @@ flag_t config_read(char *filename) {
 		} else if (json_compare_tok_key(buf, &tok[i], "client-call-timeout-sec")) {
 			json_get_value(buf, &tok[i+1], client_call_timeout_sec_str, sizeof(client_call_timeout_sec_str));
 			i++;
+		} else if (json_compare_tok_key(buf, &tok[i], "client-status-syslog-interval")) {
+			json_get_value(buf, &tok[i+1], client_status_syslog_interval_str, sizeof(client_status_syslog_interval_str));
+			i++;
 		} else if (json_compare_tok_key(buf, &tok[i], "allow-simultaneous-calls")) {
 			json_get_value(buf, &tok[i+1], allow_simultaneous_calls_str, sizeof(allow_simultaneous_calls_str));
 			i++;
@@ -205,6 +210,8 @@ flag_t config_read(char *filename) {
 		config_max_api_clients = atoi(max_api_clients_str);
 	if (client_call_timeout_sec_str[0])
 		config_client_call_timeout_sec = atoi(client_call_timeout_sec_str);
+	if (client_status_syslog_interval_str[0])
+		config_client_status_syslog_interval = atoi(client_status_syslog_interval_str);
 	if (allow_simultaneous_calls_str[0])
 		config_allow_simultaneous_calls = (allow_simultaneous_calls_str[0] == '1');
 	if (banlist_file_str[0])

--- a/srf-ip-conn-srv/config.c
+++ b/srf-ip-conn-srv/config.c
@@ -47,7 +47,7 @@ char config_server_contact_str[255] = {0,};
 uint16_t config_max_lastheard_entry_count = 30;
 uint16_t config_max_api_clients = 100;
 uint16_t config_client_call_timeout_sec = 3;
-uint16_t config_client_status_syslog_interval = 30;
+uint16_t config_client_status_syslog_interval_sec = 30;
 flag_t config_allow_simultaneous_calls = 0;
 char config_banlist_file_str[255] = {0,};
 
@@ -75,7 +75,7 @@ flag_t config_read(char *filename) {
 	char max_lastheard_entry_count_str[6] = {0,};
 	char max_api_clients_str[6] = {0,};
 	char client_call_timeout_sec_str[6] = {0,};
-	char client_status_syslog_interval_str[6] = {0,};
+	char client_status_syslog_interval_sec_str[6] = {0,};
 	char allow_simultaneous_calls_str[2] = {0,};
 	char banlist_file_str[255] = {0,};
 
@@ -160,8 +160,8 @@ flag_t config_read(char *filename) {
 		} else if (json_compare_tok_key(buf, &tok[i], "client-call-timeout-sec")) {
 			json_get_value(buf, &tok[i+1], client_call_timeout_sec_str, sizeof(client_call_timeout_sec_str));
 			i++;
-		} else if (json_compare_tok_key(buf, &tok[i], "client-status-syslog-interval")) {
-			json_get_value(buf, &tok[i+1], client_status_syslog_interval_str, sizeof(client_status_syslog_interval_str));
+		} else if (json_compare_tok_key(buf, &tok[i], "client-status-syslog-interval-sec")) {
+			json_get_value(buf, &tok[i+1], client_status_syslog_interval_sec_str, sizeof(client_status_syslog_interval_sec_str));
 			i++;
 		} else if (json_compare_tok_key(buf, &tok[i], "allow-simultaneous-calls")) {
 			json_get_value(buf, &tok[i+1], allow_simultaneous_calls_str, sizeof(allow_simultaneous_calls_str));
@@ -210,8 +210,8 @@ flag_t config_read(char *filename) {
 		config_max_api_clients = atoi(max_api_clients_str);
 	if (client_call_timeout_sec_str[0])
 		config_client_call_timeout_sec = atoi(client_call_timeout_sec_str);
-	if (client_status_syslog_interval_str[0])
-		config_client_status_syslog_interval = atoi(client_status_syslog_interval_str);
+	if (client_status_syslog_interval_sec_str[0])
+		config_client_status_syslog_interval_sec = atoi(client_status_syslog_interval_sec_str);
 	if (allow_simultaneous_calls_str[0])
 		config_allow_simultaneous_calls = (allow_simultaneous_calls_str[0] == '1');
 	if (banlist_file_str[0])

--- a/srf-ip-conn-srv/config.h
+++ b/srf-ip-conn-srv/config.h
@@ -48,7 +48,7 @@ extern char config_server_contact_str[255];
 extern uint16_t config_max_lastheard_entry_count;
 extern uint16_t config_max_api_clients;
 extern uint16_t config_client_call_timeout_sec;
-extern uint16_t config_client_status_syslog_interval;
+extern uint16_t config_client_status_syslog_interval_sec;
 extern flag_t config_allow_simultaneous_calls;
 extern char config_banlist_file_str[255];
 

--- a/srf-ip-conn-srv/config.h
+++ b/srf-ip-conn-srv/config.h
@@ -48,6 +48,7 @@ extern char config_server_contact_str[255];
 extern uint16_t config_max_lastheard_entry_count;
 extern uint16_t config_max_api_clients;
 extern uint16_t config_client_call_timeout_sec;
+extern uint16_t config_client_status_syslog_interval;
 extern flag_t config_allow_simultaneous_calls;
 extern char config_banlist_file_str[255];
 


### PR DESCRIPTION
#8 
Allows for ability to set the interval at which the client list is written to syslog. By default, it will be 30 seconds.